### PR TITLE
Update leaflet.dbpedialayer-src.js

### DIFF
--- a/dist/leaflet.dbpedialayer-src.js
+++ b/dist/leaflet.dbpedialayer-src.js
@@ -37,6 +37,8 @@ L.DBpediaLayer = L.LayerGroup.extend({
                         _this.dbp._ajaxWrapper(areaToLoad.current, areaToLoad.not);
                     }
                     _this.dbp.visitedBounds.push({SW: SW, NE: NE});
+                }else{                 
+                    _this.dbp.visitedBounds = [];
                 }
             }
         );


### PR DESCRIPTION
Hi,

I think it will be good and very useful if this plug-in resets the visitedBounds every time we need to disable and enable again the DBpediaLayer. 

In my opinion I consider a bug the fact we are keeping the bundle of visited bounds when we disable the plug-in and clean the markets, because when we turn it on again, the array still has the old coordinates and the query will discard to show the poi's markers again for areas we had seen before.

I think it makes sense reset the visiting bounds every time we do reload the label, and I believe this will help many guys out there..

It's my suggestion.

cheers
José Gomes
